### PR TITLE
Version uplifts for vulnerabilities. Fix for :no longer exists : org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
+			<version>2.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.jcraft</groupId>
@@ -167,7 +167,7 @@
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-            <version>4.2.1</version>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
@@ -204,7 +204,7 @@
     <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.5.1</version>
+        <version>42.7.4</version>
     </dependency>
 
         <!-- Oracle dependecy is necessary to compile -->
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.0.31</version>
+            <version>8.2.0</version>
         </dependency>
 
 		<dependency>
@@ -246,17 +246,25 @@
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-core</artifactId>
-			<version>9.0.71</version>
+			<version>9.0.95</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-jdbc</artifactId>
-			<version>9.0.71</version>
+			<version>9.0.95</version>
 		</dependency>
 
 
-		<!-- API, java.xml.bind module. Required for modern versions of MS SQL Server Drivers -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-fileupload2-javax</artifactId>
+            <version>2.0.0-M2</version>
+        </dependency>
+
+
+
+        <!-- API, java.xml.bind module. Required for modern versions of MS SQL Server Drivers -->
 		<dependency>
 		    <groupId>jakarta.xml.bind</groupId>
 		    <artifactId>jakarta.xml.bind-api</artifactId>
@@ -273,7 +281,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.12</version>
         </dependency>
 
 	</dependencies>

--- a/src/main/java/org/kawanfw/sql/servlet/ServerSqlDispatch.java
+++ b/src/main/java/org/kawanfw/sql/servlet/ServerSqlDispatch.java
@@ -11,22 +11,9 @@
  */
 package org.kawanfw.sql.servlet;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.SQLException;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+//see https://commons.apache.org/proper/commons-fileupload/migration.html and https://stackoverflow.com/a/79047694
+import org.apache.commons.fileupload2.javax.JavaxServletFileUpload;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.tomcat.util.http.fileupload.FileUploadException;
-import org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload;
 import org.kawanfw.sql.api.server.DatabaseConfigurator;
 import org.kawanfw.sql.api.server.firewall.SqlFirewallManager;
 import org.kawanfw.sql.metadata.dto.DatabaseInfoDto;
@@ -51,6 +38,18 @@ import org.kawanfw.sql.servlet.sql.json_return.JsonOkReturn;
 import org.kawanfw.sql.util.FrameworkDebug;
 import org.kawanfw.sql.version.VersionWrapper;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.Set;
+
 /**
  * @author Nicolas de Pomereu
  *
@@ -74,10 +73,9 @@ public class ServerSqlDispatch {
      * @param out
      * @throws IOException         if any IOException occurs
      * @throws SQLException
-     * @throws FileUploadException
      */
     public void executeRequestInTryCatch(HttpServletRequest request, HttpServletResponse response, OutputStream out)
-	    throws IOException, SQLException, FileUploadException {
+	    throws IOException, SQLException {
 
 	if (doBlobUpload(request, response, out)) {
 	    return;
@@ -517,15 +515,14 @@ public class ServerSqlDispatch {
      * @param response
      * @param out    
      * @throws IOException
-     * @throws FileUploadException
      * @throws SQLException
      */
     private boolean doBlobUpload(HttpServletRequest request, HttpServletResponse response, OutputStream out)
-	    throws IOException, FileUploadException, SQLException {
+	    throws IOException, SQLException {
 	// Immediate catch if we are asking a file upload, because
 	// parameters are in unknown sequence.
 	// We know it's a upload action if it's mime Multipart
-	if (ServletFileUpload.isMultipartContent(request)) {
+	if (JavaxServletFileUpload.isMultipartContent(request)) {
 	    BlobUploader blobUploader = new BlobUploader(request, response, out);
 	    blobUploader.blobUpload();
 	    return true;


### PR DESCRIPTION
Deal with breaking change.
import org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload; no longer exists.

As per the links below, you have to choose "one of the concretes".  This PR chose the javax version to match existing code.

See: https://commons.apache.org/proper/commons-fileupload/migration.html and https://stackoverflow.com/a/79047694